### PR TITLE
Fix: Check if friend exists before deleting in Perfil.eliminarAmigo

### DIFF
--- a/src/main/java/RedSocial/Perfil.java
+++ b/src/main/java/RedSocial/Perfil.java
@@ -31,8 +31,12 @@ public class Perfil {
     
     // Método para eliminar un amigo 
     public void eliminarAmigo(String amigo) {
+    	if (listaAmigos.contains(amigo)) {
     		listaAmigos.remove(amigo);  
-        System.out.println("Amigo eliminado: " + amigo);
+            System.out.println(amigo + " ha sido eliminado de la lista de amigos de " + nombre);
+    	} else {
+            System.out.println(amigo + " no se encontró en la lista de amigos de " + nombre);
+    	}
     }
     
     public List<String> listaAmigos ()

--- a/src/test/java/RedSocialTest/PerfilTest.java
+++ b/src/test/java/RedSocialTest/PerfilTest.java
@@ -25,10 +25,23 @@ class PerfilTest {
 
     @Test
     void testEliminarAmigo() {
-        perfil.agregarAmigo("Bob");
-        perfil.eliminarAmigo("Bob");
+        // Perfil instance is already created in setUp() and available as 'perfil'
+
+        // Add a few friends to the profile's friend list
+        perfil.agregarAmigo("Amigo1");
+        perfil.agregarAmigo("Amigo2");
+
+        // Test deleting an existing friend
+        perfil.eliminarAmigo("Amigo1");
         List<String> amigos = perfil.listaAmigos();
-        assertFalse(amigos.contains("Bob"));
+        assertFalse(amigos.contains("Amigo1"), "Amigo1 should be removed");
+        assertTrue(amigos.contains("Amigo2"), "Amigo2 should still be in the list");
+
+        // Test deleting a non-existing friend
+        perfil.eliminarAmigo("Amigo3"); // Amigo3 was never added
+        amigos = perfil.listaAmigos(); // Re-fetch the list to ensure it's current
+        assertTrue(amigos.contains("Amigo2"), "Amigo2 should still be in the list after trying to remove a non-existing friend");
+        assertEquals(1, amigos.size(), "Friend list size should be 1 (only Amigo2) after attempting to remove a non-existing friend");
     }
 
 


### PR DESCRIPTION
I've modified the `eliminarAmigo` method in the `Perfil` class to include a check for the existence of a friend in the friend list before attempting to remove them. This prevents errors and ensures that the operation is only performed if the friend is actually present.

Additionally, appropriate messages are now printed to the console indicating whether the friend was successfully removed or not found in the list.

I also added a new unit test, `testEliminarAmigo`, to `PerfilTest.java` to verify the corrected behavior. This test covers scenarios for deleting an existing friend and attempting to delete a non-existing friend, asserting the integrity of the friend list in both cases.